### PR TITLE
Fix unbound variable when scheduling alarms

### DIFF
--- a/timers.sh
+++ b/timers.sh
@@ -129,8 +129,10 @@ schedule_timer() {
         echo "$end TIMER $! $msg" >> "$TIMER_LOG"
 
     else  # ALARM
-        local epoch=$(alarm_to_epoch "$time_spec") || { echo "Bad date."; return 1; }
-        local now=$(date +%s) delay=$((epoch-now))
+        local epoch delay now
+        epoch=$(alarm_to_epoch "$time_spec") || { echo "Bad date."; return 1; }
+        now=$(date +%s)
+        delay=$((epoch-now))
         (( delay>0 )) || { echo "Time is past."; return 1; }
         (
             sleep "$delay"


### PR DESCRIPTION
## Summary
- separate alarm time calculations to avoid using undefined `now`

## Testing
- `bash -n timers.sh`
- `bash timers.sh -m "go downstairs" -a 17:45`

------
https://chatgpt.com/codex/tasks/task_e_684cf91f473c832f9e65233163aba3da