### PR TITLE
Support message as first arg

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,15 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: make test
+        shell: bash

--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,6 @@ uninstall:
 	rm -f ~/.local/bin/timers
 	sed -i '/export PATH=\$HOME\/.local\/bin:\$PATH/d' ~/.bashrc
 	sed -i '/export PATH=\$HOME\/.local\/bin:\$PATH/d' ~/.zshrc
+
+test:
+	./tests/test.sh

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Usage
 ```
-Usage: timers [-m "message"] [time] [-c to cancel timers] [-s to list timers]
+Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list timers]
 ```
 
 ### Arguments
@@ -27,13 +27,13 @@ Usage: timers [-m "message"] [time] [-c to cancel timers] [-s to list timers]
 ### Examples
 #### Setting a Timer
 ```bash
-timers -m "Break time" 10m
+timers "Break time" 10m
 ```
 Starts a **10-minute timer** with the message "Break time".
 
 #### Setting an Alarm
 ```bash
-timers -m "Meeting" 14:30
+timers "Meeting" 14:30
 ```
 Schedules an **alarm for 2:30 PM** with the message "Meeting".
 
@@ -77,3 +77,15 @@ Clone the repo and run:
 ```bash
 make install
 ```
+
+## Running Tests
+
+Run the shell test suite locally with:
+
+```bash
+make test
+```
+
+These tests are also executed automatically on GitHub via
+[GitHub Actions](https://docs.github.com/actions) for every push
+and pull request.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "$0")/.." && pwd)"
+script="$script_dir/timers.sh"
+
+run_test() {
+    local name=$1; shift
+    if "$@"; then
+        echo "$name: ok"
+    else
+        echo "$name: fail" >&2
+        exit 1
+    fi
+}
+
+test_implicit_message() {
+    tmp=$(mktemp -d)
+    HOME="$tmp" "$script" test 1s
+    line=$(cat "$tmp/.timers")
+    [[ $line == *"TIMER"* && $line == *" test" ]] 
+}
+
+test_explicit_message() {
+    tmp=$(mktemp -d)
+    HOME="$tmp" "$script" -m foo 1s
+    line=$(cat "$tmp/.timers")
+    [[ $line == *"TIMER"* && $line == *" foo" ]]
+}
+
+test_missing_args() {
+    tmp=$(mktemp -d)
+    if HOME="$tmp" "$script" 1s >"$tmp/out" 2>&1; then
+        return 1
+    fi
+    grep -q "Msg and time required." "$tmp/out"
+}
+
+run_test implicit_message test_implicit_message
+run_test explicit_message test_explicit_message
+run_test missing_args test_missing_args
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary
- allow timer message as the first argument
- avoid `bc` requirement by using awk in `parse_time`
- document the new calling style
- add simple shell tests and a `make test` target
- run tests with GitHub Actions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68591e429ec8832fa2d102edddd393d7