### PR TITLE
Fix timer log path and handle special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ interval=20
 This will refresh the display every 20 seconds, showing currently active timers in the i3bar.
 
 ## Log File
-Timers and alarms are stored in `~/.timers`. The script periodically cleans up expired entries.
+Timers and alarms are stored in `$XDG_CACHE_HOME/timers` (default `~/.cache/timers`).
+The script periodically cleans up expired entries.
 
 ## Error Handling
 - If an invalid time format is provided, the script returns an error instead of passing it to `date`.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -16,28 +16,37 @@ run_test() {
 
 test_implicit_message() {
     tmp=$(mktemp -d)
-    HOME="$tmp" "$script" test 1s
-    line=$(cat "$tmp/.timers")
-    [[ $line == *"TIMER"* && $line == *" test" ]] 
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" test 1s
+    line=$(cat "$tmp/.cache/timers")
+    [[ $line == *"TIMER"* && $line == *" test" ]]
 }
 
 test_explicit_message() {
     tmp=$(mktemp -d)
-    HOME="$tmp" "$script" -m foo 1s
-    line=$(cat "$tmp/.timers")
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" -m foo 1s
+    line=$(cat "$tmp/.cache/timers")
     [[ $line == *"TIMER"* && $line == *" foo" ]]
 }
 
 test_missing_args() {
     tmp=$(mktemp -d)
-    if HOME="$tmp" "$script" 1s >"$tmp/out" 2>&1; then
+    if XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" 1s >"$tmp/out" 2>&1; then
         return 1
     fi
     grep -q "Msg and time required." "$tmp/out"
 }
 
+test_special_chars() {
+    tmp=$(mktemp -d)
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" 'foo|bar' 1s >"$tmp/out" 2>&1
+    sleep 2
+    grep -q 'sed:' "$tmp/out" && return 1
+    grep -q "✔" "$tmp/.cache/timers"
+}
+
 run_test implicit_message test_implicit_message
 run_test explicit_message test_explicit_message
 run_test missing_args test_missing_args
+run_test special_chars test_special_chars
 
 echo "All tests passed."


### PR DESCRIPTION
## Summary
- store timers under `$XDG_CACHE_HOME` instead of the home directory
- add `remove_log_line` helper to avoid `sed` errors with special characters
- test special character handling

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68592f33bfec832f81b3d08f16c9d7e6