### PR TITLE
Change timer separator to vertical bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Schedules an **alarm for 2:30 PM** with the message "Meeting".
 timers
 ```
 Displays all active timers and alarms in a user-friendly format.
+When more than one timer is active, they are separated by `|`.
 
 ### Show Active Timers in HH:MM:SS
 ```bash

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -49,4 +49,14 @@ run_test explicit_message test_explicit_message
 run_test missing_args test_missing_args
 run_test special_chars test_special_chars
 
+test_pipe_delimiter() {
+    tmp=$(mktemp -d)
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" foo 2s
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" bar 2s
+    out=$(XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" -s)
+    [[ $out == *" | "* ]]
+}
+
+run_test pipe_delimiter test_pipe_delimiter
+
 echo "All tests passed."

--- a/timers.sh
+++ b/timers.sh
@@ -223,8 +223,16 @@ list_timers() {
         fi
     done < "$TIMER_LOG"
 
-    if (( vertical )); then printf '%s\n' "${out[@]}"; else
-        local IFS=", "; echo "${out[*]}"
+    if (( vertical )); then
+        printf '%s\n' "${out[@]}"
+    else
+        if [[ ${#out[@]} -gt 0 ]]; then
+            printf '%s' "${out[0]}"
+            for item in "${out[@]:1}"; do
+                printf ' | %s' "$item"
+            done
+            echo
+        fi
     fi
 }
 


### PR DESCRIPTION
## Summary
- show timers separated with a `|` character when listed horizontally
- document the pipe separator in README
- test for pipe output

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68593584b100832fb94d247f6243d5ee