### PR TITLE
Fix duplicate completed timer display

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -59,4 +59,31 @@ test_pipe_delimiter() {
 
 run_test pipe_delimiter test_pipe_delimiter
 
+test_no_duplicate_checkmarks() {
+    tmp=$(mktemp -d)
+    fakebin="$tmp/fakebin"
+    mkdir -p "$fakebin"
+    cat <<'EOF' > "$fakebin/date"
+#!/usr/bin/env bash
+if [[ $1 == '+%s' ]]; then
+    echo 1000
+else
+    /usr/bin/date "$@"
+fi
+EOF
+    chmod +x "$fakebin/date"
+
+    mkdir -p "$tmp/.cache"
+    cat <<'EOF' > "$tmp/.cache/timers"
+1000 TIMER 123 test
+1000 ✔ test
+EOF
+
+    PATH="$fakebin:$PATH" XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" \
+        "$script" >"$tmp/out"
+    [[ $(grep -c 'test ✔' "$tmp/out") -eq 1 ]]
+}
+
+run_test no_duplicate_checkmarks test_no_duplicate_checkmarks
+
 echo "All tests passed."

--- a/timers.sh
+++ b/timers.sh
@@ -69,7 +69,7 @@ cleanup_timers() {
     tmpfile=$(mktemp "${TIMER_LOG}.XXXXXX")
     awk -v now="$now" -v age="$CLEANUP_AGE" -v ok="$CHECKMARK_EMOJI" '
         ($2==ok)                   { if ($1+age >= now) print; next }
-        ($2=="TIMER"||$2=="ALARM"){ if ($1     >= now) print; next }
+        ($2=="TIMER"||$2=="ALARM"){ if ($1     >  now) print; next }
         { print }
     ' "$TIMER_LOG" > "$tmpfile"
     [[ -s $tmpfile ]] && mv "$tmpfile" "$TIMER_LOG" || rm -f "$tmpfile"


### PR DESCRIPTION
## Summary
- prune timers as soon as they expire
- add regression test for duplicate completed timers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685940c5370c832fb69268e9d9e0a4b5