### PR TITLE
Add window listing and retire -a option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Usage
 ```
-Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list timers]
+Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list timers] [-n duration] [--all]
 ```
 
 ### Arguments
@@ -20,9 +20,10 @@ Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list 
 |--------|-------------|
 | `-m "message"` | A message to associate with the timer or alarm. |
 | `[time]` | The duration for a timer (e.g., `5m`, `1h`, `30s`) or the specific time for an alarm (`HH:MM`). |
-| `-a` | (Optional) Force treating the input as an alarm. Normally the script detects whether the time is a countdown or clock time. |
 | `-c` | Cancels an existing timer or alarm via a numbered list. |
 | `-s` | Display remaining timers in HH:MM:SS. |
+| `-n <duration>` | Only show the timer when less than this duration remains. |
+| `--all` | List all timers regardless of their show window. |
 
 ### Examples
 #### Setting a Timer
@@ -37,11 +38,18 @@ timers "Meeting" 14:30
 ```
 Schedules an **alarm for 2:30 PM** with the message "Meeting".
 
+#### Timer with a Show Window
+```bash
+timers "pick up Harry" 16:00 -n 30m
+```
+The timer will only appear in the list 30 minutes before 4:00 PM.
+
 #### Listing Active Timers and Alarms
 ```bash
 timers
 ```
-Displays all active timers and alarms in a user-friendly format.
+Displays active timers and alarms in a user-friendly format.
+Use `--all` to show every timer regardless of its window.
 When more than one timer is active, they are separated by `|`.
 
 ### Show Active Timers in HH:MM:SS

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -86,4 +86,28 @@ EOF
 
 run_test no_duplicate_checkmarks test_no_duplicate_checkmarks
 
+test_show_window_and_all() {
+    tmp=$(mktemp -d)
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" -n 2s test 4s
+    out=$(XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script")
+    [[ -z $out ]]
+    out=$(XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" --all)
+    [[ $out == *test* ]]
+    sleep 3
+    out=$(XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script")
+    [[ $out == *test* ]]
+}
+
+run_test show_window_and_all test_show_window_and_all
+
+test_auto_alarm() {
+    tmp=$(mktemp -d)
+    target=$(date -d '1 minute' '+%H:%M')
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" test "$target"
+    line=$(cat "$tmp/.cache/timers")
+    [[ $line == *"ALARM"* ]]
+}
+
+run_test auto_alarm test_auto_alarm
+
 echo "All tests passed."


### PR DESCRIPTION
## Summary
- drop redundant `-a` flag and rely on automatic alarm detection
- document new listing flags in the README
- test show-window and `--all` behaviour

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859be7cbc44832fb6985cfbdab0fef6