### PR TITLE
Fix alarm rollover for past times

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -110,4 +110,25 @@ test_auto_alarm() {
 
 run_test auto_alarm test_auto_alarm
 
+test_alarm_rollover() {
+    tmp=$(mktemp -d)
+    target=$(date -d '1 minute ago' '+%H:%M')
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" test "$target" >"$tmp/out" 2>&1
+    line=$(cat "$tmp/.cache/timers")
+    grep -q "ALARM" "$tmp/.cache/timers"
+    grep -q "Warning" "$tmp/out"
+}
+
+run_test alarm_rollover test_alarm_rollover
+
+test_time_first_date() {
+    tmp=$(mktemp -d)
+    t=$(date -d '1 minute' '+%H:%M')
+    d=$(date -d 'tomorrow' '+%Y-%m-%d')
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" test $t $d
+    grep -q "ALARM" "$tmp/.cache/timers"
+}
+
+run_test time_first_date test_time_first_date
+
 echo "All tests passed."

--- a/timers.sh
+++ b/timers.sh
@@ -153,7 +153,7 @@ schedule_timer() {
         shift
     fi
 
-    time_spec=$1
+    time_spec="$*"
     [[ -z $msg || -z $time_spec ]] && { echo "Msg and time required."; return 1; }
 
     local secs parsed=0
@@ -175,6 +175,11 @@ schedule_timer() {
         local epoch delay
         epoch=$(alarm_to_epoch "$time_spec") || { echo "Bad date."; return 1; }
         delay=$((epoch-$(date +%s)))
+        if (( delay<=0 )) && [[ $time_spec =~ ^[0-9]{1,2}:[0-9]{2}$ ]]; then
+            echo "Warning: time has passed today; scheduling for tomorrow." >&2
+            epoch=$((epoch+86400))
+            delay=$((epoch-$(date +%s)))
+        fi
         (( delay>0 )) || { echo "Time is past."; return 1; }
         schedule_entry "$epoch" "ALARM" "$window" "$msg"
     fi


### PR DESCRIPTION
## Summary
- fix scheduling alarms when the provided HH:MM is already past
- add regression test for past alarm rollover
- warn user when past time is rolled over
- allow specifying alarms as `HH:MM YYYY-MM-DD`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6859c37b6b28832f8497585cfead3c81