### PR TITLE
Add XDG config note and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ Add a custom module in your Waybar configuration:
 Timers and alarms are stored in `$XDG_CACHE_HOME/timers` (default `~/.cache/timers`).
 The script periodically cleans up expired entries.
 
+## Notifications
+If `notify-send` or `makoctl` is available, Timers can display desktop
+notifications. Configuration is read from
+`$XDG_CONFIG_HOME/timers/config` (default `~/.config/timers/config`). The
+script honours `$XDG_CONFIG_HOME` if set and falls back to `~/.config`
+otherwise. The file supports two optional settings:
+
+```
+notify_on_create=0
+notify_on_expire=1
+```
+
+Set each value to `1` to enable or `0` to disable the corresponding
+alert. By default creation alerts are disabled and expiration alerts
+are enabled.
+
 ## Error Handling
 - If an invalid time format is provided, the script returns an error instead of passing it to `date`.
 - If the provided time is in the past, the script notifies the user instead of scheduling an invalid alarm.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -131,4 +131,65 @@ test_time_first_date() {
 
 run_test time_first_date test_time_first_date
 
+test_default_notifications() {
+    tmp=$(mktemp -d)
+    fakebin="$tmp/fakebin"
+    mkdir -p "$fakebin"
+    cat <<EOF > "$fakebin/notify-send"
+#!/usr/bin/env bash
+echo notify >> "$tmp/out"
+EOF
+    chmod +x "$fakebin/notify-send"
+    PATH="$fakebin:$PATH" XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" \
+        "$script" test 1s
+    sleep 2
+    [[ $(grep -c notify "$tmp/out" 2>/dev/null || true) -eq 1 ]]
+}
+
+run_test default_notifications test_default_notifications
+
+test_disable_notifications() {
+    tmp=$(mktemp -d)
+    fakebin="$tmp/fakebin"
+    mkdir -p "$fakebin"
+    cat <<EOF > "$fakebin/notify-send"
+#!/usr/bin/env bash
+echo notify >> "$tmp/out"
+EOF
+    chmod +x "$fakebin/notify-send"
+    mkdir -p "$tmp/.config/timers"
+    cat <<EOF > "$tmp/.config/timers/config"
+notify_on_create=1
+notify_on_expire=0
+EOF
+    PATH="$fakebin:$PATH" XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" \
+        "$script" test 1s
+    sleep 2
+    [[ $(grep -c notify "$tmp/out" 2>/dev/null || true) -eq 1 ]]
+}
+
+run_test disable_notifications test_disable_notifications
+
+test_xdg_config_home() {
+    tmp=$(mktemp -d)
+    fakebin="$tmp/fakebin"
+    mkdir -p "$fakebin"
+    cat <<EOF > "$fakebin/notify-send"
+#!/usr/bin/env bash
+echo notify >> "$tmp/out"
+EOF
+    chmod +x "$fakebin/notify-send"
+    mkdir -p "$tmp/conf/timers"
+    cat <<EOF > "$tmp/conf/timers/config"
+notify_on_create=1
+notify_on_expire=0
+EOF
+    PATH="$fakebin:$PATH" XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" \
+        XDG_CONFIG_HOME="$tmp/conf" "$script" test 1s
+    sleep 2
+    [[ $(grep -c notify "$tmp/out" 2>/dev/null || true) -eq 1 ]]
+}
+
+run_test xdg_config_home test_xdg_config_home
+
 echo "All tests passed."


### PR DESCRIPTION
## Summary
- add notification support what can be turned off in config file
- clarify that config honors `$XDG_CONFIG_HOME`
- add test that loads config from a custom XDG config path

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6859c8b4fbc0832f95b358f046ace132