### PR TITLE
Add --config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Usage
 ```
-Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list timers] [-n duration] [--all]
+Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list timers] [-n duration] [--all] [--config]
 ```
 
 ### Arguments
@@ -24,6 +24,7 @@ Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list 
 | `-s` | Display remaining timers in HH:MM:SS. |
 | `-n <duration>` | Only show the timer when less than this duration remains. |
 | `--all` | List all timers regardless of their show window. |
+| `--config` | Open the configuration file in the default editor. |
 
 ### Examples
 #### Setting a Timer
@@ -102,6 +103,7 @@ notify_on_expire=1
 Set each value to `1` to enable or `0` to disable the corresponding
 alert. By default creation alerts are disabled and expiration alerts
 are enabled.
+Use `timers --config` to create or edit this file in your preferred editor.
 
 ## Error Handling
 - If an invalid time format is provided, the script returns an error instead of passing it to `date`.

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -192,4 +192,20 @@ EOF
 
 run_test xdg_config_home test_xdg_config_home
 
+test_config_flag() {
+    tmp=$(mktemp -d)
+    fakebin="$tmp/fakebin"
+    mkdir -p "$fakebin"
+    cat <<EOF > "$fakebin/editor"
+#!/usr/bin/env bash
+echo "\$@" > "$tmp/out"
+EOF
+    chmod +x "$fakebin/editor"
+    PATH="$fakebin:$PATH" EDITOR="$fakebin/editor" \
+        XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" --config
+    grep -q "$tmp/.config/timers/config" "$tmp/out"
+}
+
+run_test config_flag test_config_flag
+
 echo "All tests passed."

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -202,7 +202,8 @@ echo "\$@" > "$tmp/out"
 EOF
     chmod +x "$fakebin/editor"
     PATH="$fakebin:$PATH" EDITOR="$fakebin/editor" \
-        XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" --config
+        XDG_CACHE_HOME="$tmp/.cache" XDG_CONFIG_HOME= HOME="$tmp" \
+        "$script" --config
     grep -q "$tmp/.config/timers/config" "$tmp/out"
 }
 

--- a/timers.sh
+++ b/timers.sh
@@ -35,6 +35,14 @@ if [[ -f $CONFIG_FILE ]]; then
     done < "$CONFIG_FILE"
 fi
 
+# Open the config file in the user's editor
+open_config() {
+    mkdir -p "$CONFIG_DIR"
+    touch "$CONFIG_FILE"
+    local editor="${EDITOR:-${VISUAL:-vi}}"
+    "$editor" "$CONFIG_FILE"
+}
+
 # Send a desktop notification if possible
 notify() {
     local title=$1 body=$2
@@ -293,6 +301,8 @@ list_timers() {
 # --------------------------------------------------------------------
 if [[ $# -eq 0 ]]; then
     list_timers
+elif [[ $# -eq 1 && $1 == --config ]]; then
+    open_config
 else
     only_flags=1
     for arg in "$@"; do


### PR DESCRIPTION
## Summary
- add `--config` flag to open the timers config file in the default editor
- document the new flag in README
- test opening the config file via `--config`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859d1f36780832f9f7e2b17419add8e