### PR TITLE
Add help flag and -a shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Usage
 ```
-Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list timers] [-n duration] [--all] [--config]
+Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list timers] [-n duration] [-a|--all] [--config] [-h]
 ```
 
 ### Arguments
@@ -23,8 +23,9 @@ Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list 
 | `-c` | Cancels an existing timer or alarm via a numbered list. |
 | `-s` | Display remaining timers in HH:MM:SS. |
 | `-n <duration>` | Only show the timer when less than this duration remains. |
-| `--all` | List all timers regardless of their show window. |
+| `-a`, `--all` | List all timers regardless of their show window. |
 | `--config` | Open the configuration file in the default editor. |
+| `-h`, `--help` | Show help information. |
 
 ### Examples
 #### Setting a Timer

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -93,6 +93,8 @@ test_show_window_and_all() {
     [[ -z $out ]]
     out=$(XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" --all)
     [[ $out == *test* ]]
+    out=$(XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" -a)
+    [[ $out == *test* ]]
     sleep 3
     out=$(XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script")
     [[ $out == *test* ]]
@@ -208,5 +210,13 @@ EOF
 }
 
 run_test config_flag test_config_flag
+
+test_help_flag() {
+    tmp=$(mktemp -d)
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" -h >"$tmp/out"
+    grep -q "Usage" "$tmp/out"
+}
+
+run_test help_flag test_help_flag
 
 echo "All tests passed."

--- a/timers.sh
+++ b/timers.sh
@@ -13,6 +13,25 @@ CHECKMARK_EMOJI="✔"
 CLEANUP_AGE=300        # seconds
 TIMERS_VERSION="v2025-05-19"
 
+# Display usage information
+print_help() {
+    cat <<'EOF'
+Usage: timers [-m "msg"] [msg] time [-c] [-n window]
+       timers [-s] [-1] [-a|--all]
+       timers [--config]
+
+Options:
+  -m msg        Set the timer or alarm message
+  -c            Cancel a timer or alarm
+  -n duration   Show timer when less than duration remains
+  -s            Show remaining time in HH:MM:SS
+  -1            Output one item per line
+  -a, --all     Show all timers regardless of window
+  --config      Edit the configuration file
+  -h, --help    Show this help message
+EOF
+}
+
 # Ensure log file exists early so background grep calls never fail
 mkdir -p "$(dirname "$TIMER_LOG")"
 touch "$TIMER_LOG"
@@ -237,7 +256,7 @@ list_timers() {
         case $arg in
             -s) use_secs=1 ;;
             -1) vertical=1 ;;
-            --all) show_all=1 ;;
+            -a|--all) show_all=1 ;;
         esac
     done
 
@@ -299,6 +318,15 @@ list_timers() {
 # --------------------------------------------------------------------
 # Entry
 # --------------------------------------------------------------------
+for arg in "$@"; do
+    case $arg in
+        -h|--help)
+            print_help
+            exit 0
+            ;;
+    esac
+done
+
 if [[ $# -eq 0 ]]; then
     list_timers
 elif [[ $# -eq 1 && $1 == --config ]]; then
@@ -307,7 +335,7 @@ else
     only_flags=1
     for arg in "$@"; do
         case $arg in
-            -s|-1|--all) ;;
+            -s|-1|-a|--all) ;;
             *) only_flags=0; break ;;
         esac
     done


### PR DESCRIPTION
## Summary
- add `print_help` function and process `-h/--help`
- allow `-a` as shorthand for `--all`
- document new flags in README
- extend tests for new behaviour

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859d8a8b4ec832fa0d175e2f9d16560