### PR TITLE
Add JSON output option

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Usage
 ```
-Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list timers] [-n duration] [-p] [-a|--all] [--config] [-h]
+Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list timers] [-n duration] [-p] [-a|--all] [--json] [--config] [-h]
 ```
 
 ### Arguments
@@ -28,6 +28,7 @@ Usage: timers [-m "message"] [message] [time] [-c to cancel timers] [-s to list 
 | `-n <duration>` | Only show the timer when less than this duration remains. |
 | `-p` | Play a sound when the timer finishes. |
 | `-a`, `--all` | List all timers regardless of their show window. |
+| `--json` | Output timers in JSON format. |
 | `--config` | Open the configuration file in the default editor. |
 | `-h`, `--help` | Show help information. |
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -219,4 +219,13 @@ test_help_flag() {
 
 run_test help_flag test_help_flag
 
+test_json_output() {
+    tmp=$(mktemp -d)
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" foo 5s
+    out=$(XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" --json)
+    echo "$out" | jq -e '.[0] | .name=="foo" and .label=="TIMER" and has("id") and has("emoji") and has("expiration") and has("sound")' >/dev/null
+}
+
+run_test json_output test_json_output
+
 echo "All tests passed."


### PR DESCRIPTION
## Summary
- add `--json` flag to output timers in JSON format
- track per-timer sound flag in the log
- document new option in README
- test JSON output

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859e8d57e24832fa89808e191de77f2