### PR TITLE
Fix timer CLI hanging on invalid time

### DIFF
--- a/tests/test.sh
+++ b/tests/test.sh
@@ -239,15 +239,14 @@ test_cleanup_on_start() {
 
 run_test cleanup_on_start test_cleanup_on_start
 
-test_bad_date_with_window() {
+test_window_option_after_time() {
     tmp=$(mktemp -d)
-    if XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" test 9:00 -n 30m >"$tmp/out" 2>&1; then
-        return 1
-    fi
-    grep -q "Bad date." "$tmp/out"
+    target=$(date -d '1 minute' '+%H:%M')
+    XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" test "$target" -n 30m
+    grep -q "ALARM" "$tmp/.cache/timers"
 }
 
-run_test bad_date_with_window test_bad_date_with_window
+run_test window_option_after_time test_window_option_after_time
 
 run_test cleanup_age_config 
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -239,6 +239,16 @@ test_cleanup_on_start() {
 
 run_test cleanup_on_start test_cleanup_on_start
 
+test_bad_date_with_window() {
+    tmp=$(mktemp -d)
+    if XDG_CACHE_HOME="$tmp/.cache" HOME="$tmp" "$script" test 9:00 -n 30m >"$tmp/out" 2>&1; then
+        return 1
+    fi
+    grep -q "Bad date." "$tmp/out"
+}
+
+run_test bad_date_with_window test_bad_date_with_window
+
 run_test cleanup_age_config 
 
 echo "All tests passed."

--- a/timers.sh
+++ b/timers.sh
@@ -136,15 +136,16 @@ format_remaining() {
 # 1h20m10s → seconds
 parse_duration() {
     local s=0 input=$1
-    while [[ $input =~ ([0-9]*\.?[0-9]+)([hms]) ]]; do
+    while [[ $input =~ ^[[:space:]]*([0-9]*\.?[0-9]+)([hms])(.*) ]]; do
         num=${BASH_REMATCH[1]} unit=${BASH_REMATCH[2]}
+        input=${BASH_REMATCH[3]}
         case $unit in
             h) s=$(awk -v s="$s" -v n="$num" 'BEGIN{print s+n*3600}') ;;
             m) s=$(awk -v s="$s" -v n="$num" 'BEGIN{print s+n*60}')  ;;
             s) s=$(awk -v s="$s" -v n="$num" 'BEGIN{print s+n}')     ;;
         esac
-        input=${input#${BASH_REMATCH[0]}}
     done
+    input=${input//[[:space:]]/}
     [[ -n $input ]] && { echo "Could not parse '$input'." >&2; return 1; }
     printf '%d' "${s%.*}"
 }


### PR DESCRIPTION
## Summary
- fix infinite loop when parsing durations containing invalid chars
- exit with `Bad date` message for `timers test 9:00 -n 30m`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6859fb84bdc0832f89d7a153ec93c076